### PR TITLE
feat: add toast notifications to authentication pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.56.3",
+        "react-hot-toast": "^2.5.2",
         "sonner": "^2.0.3",
         "supabase": "^2.22.6",
         "swagger": "^0.7.5",
@@ -7710,6 +7711,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -11367,6 +11377,23 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.3",
+    "react-hot-toast": "^2.5.2",
     "sonner": "^2.0.3",
     "supabase": "^2.22.6",
     "swagger": "^0.7.5",

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -4,8 +4,9 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import supabase from '../lib/supabase'
 import Link from 'next/link'
-import axios, { AxiosError } from 'axios' // เพิ่ม import AxiosError
+import axios, { AxiosError } from 'axios'
 import { loginSchema, LoginFormInputs } from '../schemas/auth'
+import toast, { Toaster } from 'react-hot-toast' // เพิ่ม import สำหรับ toast
 
 // สร้าง interface สำหรับ error response
 interface ErrorResponse {
@@ -38,8 +39,15 @@ export default function LoginPage() {
       })
 
       if (res.status === 200) {
-        // เข้าสู่ระบบสำเร็จ นำทางไปยังหน้าหลัก
-        router.push('/')
+        // แสดง toast เมื่อเข้าสู่ระบบสำเร็จ
+        toast.success('เข้าสู่ระบบสำเร็จ! กำลังนำทางไปหน้าหลัก...', {
+          duration: 2000,
+        })
+
+        // รอให้ toast แสดงแล้วค่อย redirect
+        setTimeout(() => {
+          router.push('/')
+        }, 1500)
         return
       }
     } catch (error: unknown) {
@@ -60,27 +68,42 @@ export default function LoginPage() {
           document.cookie = `fallback_token=${fallbackResult.token}; path=/; max-age=86400; samesite=strict${secure}`
           document.cookie = `user_id=${fallbackResult.user.id}; path=/; max-age=86400; samesite=strict${secure}`
 
-          // นำทางไปยังหน้าหลัก
-          router.push('/')
+          // แสดง toast เมื่อเข้าสู่ระบบสำเร็จ (ระบบสำรอง)
+          toast.success('เข้าสู่ระบบสำเร็จ! กำลังนำทางไปหน้าหลัก...', {
+            duration: 2000,
+          })
+
+          // รอให้ toast แสดงแล้วค่อย redirect
+          setTimeout(() => {
+            router.push('/').catch(() => {
+              window.location.href = '/'
+            })
+          }, 1500)
           return
         } else {
-          // แสดงข้อความข้อผิดพลาดจาก API
-          setError(
+          // แสดง error toast
+          const errorMessage =
             fallbackResult.error || 'การเข้าสู่ระบบล้มเหลว กรุณาลองใหม่อีกครั้ง'
-          )
+          toast.error(errorMessage)
+          setError(errorMessage)
         }
       } catch (fallbackError: unknown) {
         // จัดการกรณีที่ API fallback-login มีปัญหา
         if (axios.isAxiosError(fallbackError)) {
           // Type guard เพื่อตรวจสอบว่าเป็น AxiosError
           const axiosError = fallbackError as AxiosError<ErrorResponse>
-          setError(
+          const errorMessage =
             axiosError.response?.data?.error ||
-              'เกิดข้อผิดพลาดในการเข้าสู่ระบบ กรุณาลองใหม่อีกครั้ง'
-          )
+            'เกิดข้อผิดพลาดในการเข้าสู่ระบบ กรุณาลองใหม่อีกครั้ง'
+
+          toast.error(errorMessage)
+          setError(errorMessage)
         } else {
           // กรณีที่เป็น error ชนิดอื่น
-          setError('เกิดข้อผิดพลาดในการเข้าสู่ระบบ กรุณาลองใหม่อีกครั้ง')
+          const errorMessage =
+            'เกิดข้อผิดพลาดในการเข้าสู่ระบบ กรุณาลองใหม่อีกครั้ง'
+          toast.error(errorMessage)
+          setError(errorMessage)
         }
       }
     } finally {
@@ -99,12 +122,19 @@ export default function LoginPage() {
       })
 
       if (error) {
+        toast.error(error.message)
         setError(error.message)
+      } else {
+        // แสดง toast เมื่อเริ่มกระบวนการ login ด้วย Facebook
+        toast.loading('กำลังเข้าสู่ระบบด้วย Facebook...', {
+          duration: 3000,
+        })
       }
     } catch {
-      setError(
+      const errorMessage =
         'เกิดข้อผิดพลาดในการเข้าสู่ระบบด้วย Facebook กรุณาลองใหม่อีกครั้ง'
-      )
+      toast.error(errorMessage)
+      setError(errorMessage)
     }
   }
 
@@ -212,6 +242,38 @@ export default function LoginPage() {
             </p>
           </div>
         </div>
+
+        {/* เพิ่ม Toaster component ที่นี่เพื่อให้ toast สามารถแสดงผลได้ */}
+        <Toaster
+          position="top-center"
+          toastOptions={{
+            duration: 3000,
+            style: {
+              background: '#363636',
+              color: '#fff',
+            },
+            success: {
+              duration: 2000,
+              iconTheme: {
+                primary: '#4ade80',
+                secondary: '#fff',
+              },
+            },
+            error: {
+              duration: 4000,
+              iconTheme: {
+                primary: '#ef4444',
+                secondary: '#fff',
+              },
+            },
+            loading: {
+              iconTheme: {
+                primary: '#3b82f6',
+                secondary: '#fff',
+              },
+            },
+          }}
+        />
       </div>
     </>
   )

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -4,9 +4,10 @@ import { useRouter } from 'next/router'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { termsContent, privacyContent } from '../data/legal'
 import Link from 'next/link'
-import axios, { AxiosError } from 'axios' // เพิ่ม import AxiosError
+import axios, { AxiosError } from 'axios'
 import { registerSchema, RegisterFormInputs } from '../schemas/auth'
 import LegalModal from '@/components/shared/LegalModal'
+import toast, { Toaster } from 'react-hot-toast' // เพิ่ม import Toaster ด้วย
 
 // สร้าง interface สำหรับ error response
 interface ErrorResponse {
@@ -44,27 +45,47 @@ export default function RegisterPage() {
         tel: data.phone,
       })
 
-      // ถ้าสำเร็จ นำทางไปยังหน้า login
+      // ถ้าสำเร็จ แสดง toast และนำทางไปยังหน้า login
       if (res.status === 201) {
-        router.push('/login')
+        // แสดง toast notification เมื่อลงทะเบียนสำเร็จ (แบบง่าย)
+        toast.success('ลงทะเบียนสำเร็จ! กำลังนำทางไปหน้าเข้าสู่ระบบ...', {
+          duration: 2000,
+        })
+
+        // รอให้ toast แสดงประมาณ 1.5 วินาที แล้วค่อย redirect
+        setTimeout(() => {
+          router.push('/login')
+        }, 1500)
+
         return
       }
     } catch (error: unknown) {
       // ใช้ axios.isAxiosError เพื่อตรวจสอบว่าเป็น AxiosError
       if (axios.isAxiosError(error)) {
         const axiosError = error as AxiosError<ErrorResponse>
-        // เข้าถึง message จาก response data อย่างปลอดภัย
-        setError(
+        const errorMessage =
           axiosError.response?.data?.message ||
-            axiosError.response?.data?.error ||
-            'เกิดข้อผิดพลาดในการลงทะเบียน กรุณาลองใหม่อีกครั้ง'
-        )
+          axiosError.response?.data?.error ||
+          'เกิดข้อผิดพลาดในการลงทะเบียน กรุณาลองใหม่อีกครั้ง'
+
+        // แสดง error toast (แบบง่าย)
+        toast.error(errorMessage)
+
+        setError(errorMessage)
       } else if (error instanceof Error) {
         // กรณีเป็น Error ทั่วไป
-        setError(error.message || 'เกิดข้อผิดพลาดในการลงทะเบียน')
+        const errorMessage = error.message || 'เกิดข้อผิดพลาดในการลงทะเบียน'
+
+        toast.error(errorMessage)
+
+        setError(errorMessage)
       } else {
         // กรณีเป็น error ที่ไม่รู้จัก
-        setError('เกิดข้อผิดพลาดในการลงทะเบียน กรุณาลองใหม่อีกครั้ง')
+        const errorMessage = 'เกิดข้อผิดพลาดในการลงทะเบียน กรุณาลองใหม่อีกครั้ง'
+
+        toast.error(errorMessage)
+
+        setError(errorMessage)
       }
     } finally {
       setIsLoading(false)
@@ -264,6 +285,32 @@ export default function RegisterPage() {
           content={privacyContent}
         />
       </div>
+
+      {/* เพิ่ม Toaster component ที่นี่เพื่อให้ toast สามารถแสดงผลได้ */}
+      <Toaster
+        position="top-center"
+        toastOptions={{
+          duration: 3000,
+          style: {
+            background: '#363636',
+            color: '#fff',
+          },
+          success: {
+            duration: 2000,
+            iconTheme: {
+              primary: '#4ade80',
+              secondary: '#fff',
+            },
+          },
+          error: {
+            duration: 4000,
+            iconTheme: {
+              primary: '#ef4444',
+              secondary: '#fff',
+            },
+          },
+        }}
+      />
     </>
   )
 }


### PR DESCRIPTION
## 📝 Description
Added toast notifications to improve user experience during authentication flow on login and register pages.

## 🚀 Changes Made
### Registration Page (`/register`)
- ✅ Success toast when registration completes successfully
- ❌ Error toast for registration failures
- ⏱️ 1.5 second delay before redirecting to login page

### Login Page (`/login`)
- ✅ Success toast for both normal and fallback login
- ❌ Error toast for all authentication failures
- 🔄 Loading toast for Facebook OAuth login
- ⏱️ 1.5 second delay before redirecting to home page

### Technical Implementation
- Added `react-hot-toast` library
- Included `<Toaster />` component in both pages
- Improved error handling with better user feedback
- Added fallback redirect using `window.location.href`

## 🎯 Benefits
- Better user feedback during auth flow
- Improved error visibility and handling
- Enhanced user experience with visual confirmation
- Consistent toast styling across auth pages

## 🧪 Testing
- [x] Registration success flow
- [x] Registration error handling
- [x] Login success flow (normal + fallback)
- [x] Login error handling
- [x] Facebook login flow
- [x] Toast display and redirect timing

## 📦 Dependencies
- `react-hot-toast` (if not already installed)

## 📸 Screenshots/Demo
_Add screenshots of toast notifications if available_